### PR TITLE
main.js: use relative path to api/session

### DIFF
--- a/src/fah/webclient/js/main.js
+++ b/src/fah/webclient/js/main.js
@@ -1228,5 +1228,5 @@ function main(sid) {
 
 
 $(function () {
-  $.ajax({method: 'PUT', url: '/api/session?_=' + Math.random()}).done(main)
+  $.ajax({method: 'PUT', url: 'api/session?_=' + Math.random()}).done(main)
 });


### PR DESCRIPTION
Use relative paths consistently when invoking APIs.  This makes it possible to reverse-proxy the site to a different path from `/`.

Resolves #29.